### PR TITLE
release: v1.0.44

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -800,16 +800,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab"
+                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab",
-                "reference": "50e0e1314a3b2609d32b6a5a0d0fb5342494c4ab",
+                "url": "https://api.github.com/repos/symfony/config/zipball/212d54675bf203ff8aef7d8cee8eecfb72f4a263",
+                "reference": "212d54675bf203ff8aef7d8cee8eecfb72f4a263",
                 "shasum": ""
             },
             "require": {
@@ -858,7 +858,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.2.3"
+                "source": "https://github.com/symfony/config/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -874,20 +874,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:15:41+00:00"
+            "time": "2021-02-23T23:58:19+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "62f72187be689540385dce6c68a5d4c16f034139"
+                "reference": "f7d89110c55d88620dc811f342f94393b8a045d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/62f72187be689540385dce6c68a5d4c16f034139",
-                "reference": "62f72187be689540385dce6c68a5d4c16f034139",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f7d89110c55d88620dc811f342f94393b8a045d4",
+                "reference": "f7d89110c55d88620dc811f342f94393b8a045d4",
                 "shasum": ""
             },
             "require": {
@@ -905,7 +905,7 @@
             },
             "provide": {
                 "psr/container-implementation": "1.0",
-                "symfony/service-implementation": "1.0"
+                "symfony/service-implementation": "1.0|2.0"
             },
             "require-dev": {
                 "symfony/config": "^5.1",
@@ -945,7 +945,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -961,7 +961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T12:56:27+00:00"
+            "time": "2021-03-04T15:41:09+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -1032,16 +1032,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.2.3",
+            "version": "v5.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038"
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/262d033b57c73e8b59cd6e68a45c528318b15038",
-                "reference": "262d033b57c73e8b59cd6e68a45c528318b15038",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/710d364200997a5afde34d9fe57bd52f3cc1e108",
+                "reference": "710d364200997a5afde34d9fe57bd52f3cc1e108",
                 "shasum": ""
             },
             "require": {
@@ -1074,7 +1074,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.2.3"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.4"
             },
             "funding": [
                 {
@@ -1090,7 +1090,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-27T10:01:46+00:00"
+            "time": "2021-02-12T10:38:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (8676385d54718b77bd925de7929d90ce74d8e3d6)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/view/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.4)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.4)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.34)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.5.8)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.1)
  - Downloading symfony/polyfill-ctype (v1.22.1)
  - Downloading symfony/filesystem (v5.2.4)
  - Downloading psr/container (1.0.0)
  - Downloading symfony/service-contracts (v2.2.0)
  - Downloading symfony/polyfill-php80 (v1.22.1)
  - Downloading symfony/deprecation-contracts (v2.2.0)
  - Downloading symfony/dependency-injection (v5.2.4)
  - Downloading symfony/config (v5.2.4)
  - Downloading pdepend/pdepend (2.8.0)
  - Downloading psr/log (1.1.3)
  - Downloading composer/xdebug-handler (1.4.5)
  - Downloading phpmd/phpmd (2.9.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading wp-content-framework/presenter (v1.0.34)
  0/21 [>---------------------------]   0%
  8/21 [==========>-----------------]  38%
 18/21 [========================>---]  85%
 19/21 [=========================>--]  90%
 20/21 [==========================>-]  95%
 21/21 [============================] 100%  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.4): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.4): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.34): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.9 for phpmd/phpmd
Using version ^3.5 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 21 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (1.4.5)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.8.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.9.1)
  - Locking psr/container (1.0.0)
  - Locking psr/log (1.1.3)
  - Locking squizlabs/php_codesniffer (3.5.8)
  - Locking symfony/config (v5.2.4)
  - Locking symfony/dependency-injection (v5.2.4)
  - Locking symfony/deprecation-contracts (v2.2.0)
  - Locking symfony/filesystem (v5.2.4)
  - Locking symfony/polyfill-ctype (v1.22.1)
  - Locking symfony/polyfill-php80 (v1.22.1)
  - Locking symfony/service-contracts (v2.2.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.34)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 21 installs, 0 updates, 0 removals
    0 [>---------------------------]    0 [>---------------------------]    0 [>---------------------------]  - Installing squizlabs/php_codesniffer (3.5.8): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.22.1): Extracting archive
  - Installing symfony/filesystem (v5.2.4): Extracting archive
  - Installing psr/container (1.0.0): Extracting archive
  - Installing symfony/service-contracts (v2.2.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.22.1): Extracting archive
  - Installing symfony/deprecation-contracts (v2.2.0): Extracting archive
  - Installing symfony/dependency-injection (v5.2.4): Extracting archive
  - Installing symfony/config (v5.2.4): Extracting archive
  - Installing pdepend/pdepend (2.8.0): Extracting archive
  - Installing psr/log (1.1.3): Extracting archive
  - Installing composer/xdebug-handler (1.4.5): Extracting archive
  - Installing phpmd/phpmd (2.9.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.34): Extracting archive
 0/9 [>---------------------------]   0%
 9/9 [============================] 100%
 9/9 [============================] 100%9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
12 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)