### PR TITLE
release: v1.0.58

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,16 +139,16 @@
         },
         {
             "name": "wp-content-framework/presenter",
-            "version": "v1.0.47",
+            "version": "v1.0.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-content-framework/presenter.git",
-                "reference": "3aee3f61b70fd82e4d9816b9a5cb3a8e22dcab6a"
+                "reference": "d935df26a07395077493413a5ab854710ef7cec2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/3aee3f61b70fd82e4d9816b9a5cb3a8e22dcab6a",
-                "reference": "3aee3f61b70fd82e4d9816b9a5cb3a8e22dcab6a",
+                "url": "https://api.github.com/repos/wp-content-framework/presenter/zipball/d935df26a07395077493413a5ab854710ef7cec2",
+                "reference": "d935df26a07395077493413a5ab854710ef7cec2",
                 "shasum": ""
             },
             "require": {
@@ -182,7 +182,7 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-content-framework/presenter/issues",
-                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.47"
+                "source": "https://github.com/wp-content-framework/presenter/tree/v1.0.48"
             },
             "funding": [
                 {
@@ -190,7 +190,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-06-09T07:48:43+00:00"
+            "time": "2021-06-15T03:54:53+00:00"
         }
     ],
     "packages-dev": [
@@ -796,16 +796,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810"
+                "reference": "9c307728cfacbd50914f0db28aee1e0ecd82b99f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/9f4a448c2d7fd2c90882dfff930b627ddbe16810",
-                "reference": "9f4a448c2d7fd2c90882dfff930b627ddbe16810",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9c307728cfacbd50914f0db28aee1e0ecd82b99f",
+                "reference": "9c307728cfacbd50914f0db28aee1e0ecd82b99f",
                 "shasum": ""
             },
             "require": {
@@ -855,7 +855,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v5.3.0"
+                "source": "https://github.com/symfony/config/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -871,20 +871,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:43:10+00:00"
+            "time": "2021-06-12T10:15:17+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v5.3.0",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "94d973cb742d8c5c5dcf9534220e6b73b09af1d4"
+                "reference": "ddbff73bc4fa3d5b415431d486770ab0e72f6516"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/94d973cb742d8c5c5dcf9534220e6b73b09af1d4",
-                "reference": "94d973cb742d8c5c5dcf9534220e6b73b09af1d4",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/ddbff73bc4fa3d5b415431d486770ab0e72f6516",
+                "reference": "ddbff73bc4fa3d5b415431d486770ab0e72f6516",
                 "shasum": ""
             },
             "require": {
@@ -943,7 +943,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.0"
+                "source": "https://github.com/symfony/dependency-injection/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -959,7 +959,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-26T17:57:12+00:00"
+            "time": "2021-06-12T09:17:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (e3eed2bd5a3835b1de69319e28dc6111180d3cbe)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/view/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 22 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.1)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.1)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.10.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.4)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.2)
  - Locking symfony/dependency-injection (v5.3.2)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.0)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.48)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 22 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.6.0)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading matthiasmullie/path-converter (1.1.3)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.1)
  - Downloading symfony/polyfill-ctype (v1.23.0)
  - Downloading symfony/filesystem (v5.3.0)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.4.0)
  - Downloading symfony/polyfill-php80 (v1.23.0)
  - Downloading symfony/deprecation-contracts (v2.4.0)
  - Downloading symfony/dependency-injection (v5.3.2)
  - Downloading symfony/polyfill-php81 (v1.23.0)
  - Downloading symfony/config (v5.3.2)
  - Downloading pdepend/pdepend (2.9.1)
  - Downloading psr/log (1.1.4)
  - Downloading composer/xdebug-handler (2.0.1)
  - Downloading phpmd/phpmd (2.10.1)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Downloading matthiasmullie/minify (1.3.66)
  - Downloading wp-content-framework/presenter (v1.0.48)
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.0): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.2): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.2): Extracting archive
  - Installing pdepend/pdepend (2.9.1): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing composer/xdebug-handler (2.0.1): Extracting archive
  - Installing phpmd/phpmd (2.10.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.48): Extracting archive
9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 22 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.1)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking matthiasmullie/minify (1.3.66)
  - Locking matthiasmullie/path-converter (1.1.3)
  - Locking pdepend/pdepend (2.9.1)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.1)
  - Locking phpmd/phpmd (2.10.1)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.4)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.2)
  - Locking symfony/dependency-injection (v5.3.2)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.0)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
  - Locking wp-content-framework/presenter (v1.0.48)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 22 installs, 0 updates, 0 removals
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing matthiasmullie/path-converter (1.1.3): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.1): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.0): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.2): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.2): Extracting archive
  - Installing pdepend/pdepend (2.9.1): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing composer/xdebug-handler (2.0.1): Extracting archive
  - Installing phpmd/phpmd (2.10.1): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
  - Installing matthiasmullie/minify (1.3.66): Extracting archive
  - Installing wp-content-framework/presenter (v1.0.48): Extracting archive
9 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^1.0 for wp-content-framework/presenter
./composer.json has been updated
Running composer update wp-content-framework/presenter
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
13 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)